### PR TITLE
Fix: implementado validação do campo email do form.

### DIFF
--- a/app/Http/Livewire/NewsletterForm.php
+++ b/app/Http/Livewire/NewsletterForm.php
@@ -17,7 +17,7 @@ final class NewsletterForm extends Component
      */
     protected $rules = [
         'name' => 'required|min:3',
-        'email' => 'required',
+        'email' => 'required|email',
     ];
 
     /**
@@ -26,6 +26,7 @@ final class NewsletterForm extends Component
     protected $messages = [
         'required' => 'Pô, esqueceu de escrever o :attribute?',
         'min' => 'Aqui não paga por letra enviada! Manda no mínimo :min!',
+        'email' => 'Bebeu todas? Email é tipo voce@voce.com.br',
     ];
 
     public function submit(): void

--- a/app/Http/Livewire/NewsletterForm.php
+++ b/app/Http/Livewire/NewsletterForm.php
@@ -17,7 +17,7 @@ final class NewsletterForm extends Component
      */
     protected $rules = [
         'name' => 'required|min:3',
-        'email' => 'required|email',
+        'email' => 'required',
     ];
 
     /**
@@ -26,7 +26,6 @@ final class NewsletterForm extends Component
     protected $messages = [
         'required' => 'Pô, esqueceu de escrever o :attribute?',
         'min' => 'Aqui não paga por letra enviada! Manda no mínimo :min!',
-        'email' => 'Bebeu todas? Email é tipo voce@voce.com.br',
     ];
 
     public function submit(): void


### PR DESCRIPTION
Ao testar a aplicação, constarei que o campo `email` não estava sendo validado corretamente, apenas estava com a definição de ser um campo obrigatório, porém não existia validação para que a string informada fosse do tipo **email** `user@email.com`. Sem esta validação um usuário descuidado poderia cadastrar no campo email do formulário da aplicação qualquer dado diferente de um email, o que poderia ocasionar erros na aplicação ao tentarmos enviar emails para os usuários cadastrados.

Estou propondo adicionar uma regra de validação para email, na validação do formulário, desta forma não será mais permitido o cadastro incorretos. Abaixo apresento a solução.

**NewsletterForm.php**
![Captura de tela de 2021-11-26 19-35-56](https://user-images.githubusercontent.com/2080547/143659254-34b8757d-6527-47cb-8518-5871064a350e.png)

É uma má prática não validar corretamente os campos de um form, podendo gerar erros na execução da aplicação, com esta solução acredito que sanamos os possíveis erros que poderiam ocorrer na aplicação.
